### PR TITLE
fix(#343): Add support for scale sub resource

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,6 +187,10 @@ func main() {
 	}
 
 	scalesClient, err := newScalesClient(cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to create scales client")
+		os.Exit(1)
+	}
 
 	// initialize che client
 	che.InitDefaultCheClient(allNamespacesClient)
@@ -308,18 +312,18 @@ func newAllNamespacesClient(config *rest.Config) (client.Client, cache.Cache, er
 }
 
 func newScalesClient(config *rest.Config) (scale.ScalesGetter, error) {
-	if c, err := kubernetes.NewForConfig(config); err == nil {
-		// Polymorphic scale client
-		groupResources, err := restmapper.GetAPIGroupResources(c.Discovery())
-		if err != nil {
-			return nil, err
-		}
-		mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
-		resolver := scale.NewDiscoveryScaleKindResolver(c.Discovery())
-		return scale.NewForConfig(config, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
-	} else {
+	c, err := kubernetes.NewForConfig(config)
+	if err != nil {
 		return nil, err
 	}
+	// Polymorphic scale client
+	groupResources, err := restmapper.GetAPIGroupResources(c.Discovery())
+	if err != nil {
+		return nil, err
+	}
+	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
+	resolver := scale.NewDiscoveryScaleKindResolver(c.Discovery())
+	return scale.NewForConfig(config, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 }
 
 // getCRTConfiguration creates the client used for configuration and

--- a/pkg/webhook/validatingwebhook/validate.go
+++ b/pkg/webhook/validatingwebhook/validate.go
@@ -96,7 +96,7 @@ func validate(body []byte, client runtimeClient.Client) []byte {
 			}
 			//check if the requesting user is a sandbox user
 			if requestingUser.GetLabels()[toolchainv1alpha1.ProviderLabelKey] == toolchainv1alpha1.ProviderLabelValue {
-				log.Info("trying to give access which is restricted", "sandbox user is trying to create a rolebinding giving wider access", "AdmissionReview", admReview)
+				log.Info("trying to give access which is restricted: sandbox user is trying to create a rolebinding giving wider access", "AdmissionReview", admReview)
 				return denyAdmissionRequest(admReview, errors.Wrapf(fmt.Errorf("please create a rolebinding for a specific user or service account to avoid this error"), "this is a Dev Sandbox enforced restriction. you are trying to create a rolebinding giving access to a larger audience, i.e : %v and requesting user: %+v", sub.Name, requestingUser.Labels))
 			}
 			//At this point, it is clear the user isn't a sandbox user, allow request

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
Update the idler component to also support deployments managed by scale sub resources. In case a deployment is owned by a custom resource that holds a scale sub resource the idler will patch the scale resource instead of the deployment directly.

This makes sure that the idler is able to terminate deployments owned by scale resources, too.

At the moment ths is being used by Camel K workloads such as Integration and KameletBinding custom resources.